### PR TITLE
Alert sm2

### DIFF
--- a/_whatsnew/2024-10-07.adoc
+++ b/_whatsnew/2024-10-07.adoc
@@ -4,7 +4,7 @@ You can quickly identify ONTAP clusters that have low capacity or low performanc
 === Alerts details
 You can drill into alert details and find recommendations. 
 
-=== View cluster details linked to System Manager
+=== View cluster details linked to ONTAP System Manager
 With BlueXP alerts, you can view alerts associated with your ONTAP storage environment and drill into the details that are linked to ONTAP System Manager.
 
 https://docs.netapp.com/us-en/bluexp-alerts/concept-alerts.html[Learn about BlueXP alerts].

--- a/alerts-start-quick-start.adoc
+++ b/alerts-start-quick-start.adoc
@@ -1,8 +1,8 @@
 ---
 sidebar: sidebar
 permalink: alerts-start-quick-start.html
-keywords: how to get started with bluexp alerts, alerts quick start
-summary: Get started with the NetApp BlueXP alerts service in a few steps.
+keywords: how to get started with bluexp alerts, alerts quick start, netapp, ontap, alert, capacity, performance, availability, security, protection, bluexp, bluexp alerts
+summary: Get started with the BlueXP alerts service in a few steps.
 ---
 
 = Quick start for BlueXP alerts

--- a/alerts-use-dashboard.adoc
+++ b/alerts-use-dashboard.adoc
@@ -132,7 +132,7 @@ EMS alerts:
 ====
 // end of snippet
 
-For details on ONTAP alerts, refer to the ONTAP documentation and System Manager insights at https://docs.netapp.com/us-en/ontap/concepts/insights-system-optimization-concept.html[System Manager insights into capacity, security, and configuration issues^].
+For details on ONTAP alerts, refer to the ONTAP documentation and ONTAP System Manager insights at https://docs.netapp.com/us-en/ontap/concepts/insights-system-optimization-concept.html[ONTAP System Manager insights into capacity, security, and configuration issues^].
 
 
 

--- a/concept-alerts.adoc
+++ b/concept-alerts.adoc
@@ -32,7 +32,7 @@ BlueXP alerts offers the following benefits:
 
 * Get alerts about your ONTAP storage across clusters.
 * View alerts in the same BlueXP UI that you use for other services.
-* Drill into alerts on ONTAP clusters -- start from BlueXP alerts and see details in NetApp System Manager. 
+* Drill into alerts on ONTAP clusters -- start from BlueXP alerts and see details in ONTAP System Manager. 
 
 
 == Cost 


### PR DESCRIPTION
This pull request includes multiple changes to update references to "System Manager" to "ONTAP System Manager" in various documentation files. The most important changes include updates in the following files:

* [`_whatsnew/2024-10-07.adoc`](diffhunk://#diff-14ca42a7405a77211c6c5d93c46f9995ef928b2580c136e9a7ab63662afd345aL7-R7): Changed "System Manager" to "ONTAP System Manager" in the "View cluster details linked to System Manager" section.
* [`alerts-use-dashboard.adoc`](diffhunk://#diff-1f8b6d46caa65239f0d1050ad08aa3b129116d82272dad0976a9e7cac32638b4L135-R135): Updated the reference to "System Manager insights" to "ONTAP System Manager insights" in the "EMS alerts" section.
* [`concept-alerts.adoc`](diffhunk://#diff-8544767650f4f41ba9aa348ce1dc6ce239d6117b361c4ecebcb615da4816f334L35-R35): Modified the benefits section to change "NetApp System Manager" to "ONTAP System Manager".

Additionally, the following change was made to enhance keyword relevance:

* [`alerts-start-quick-start.adoc`](diffhunk://#diff-6e393ec4788a709418ae4623c551f24983b931b5eeaacff2e69bfc33d76b9647L4-R5): Expanded the keywords and simplified the summary for better search optimization.